### PR TITLE
feat: make command and args configurable via file

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,10 +35,12 @@ var (
 )
 
 type Job struct {
-	JobName        string `yaml:"name"`
-	Image          string `yaml:"image"`
-	Namespace      string `yaml:"namespace"`
-	ServiceAccount string `yaml:"service_account,omitempty"`
+	JobName        string   `yaml:"name"`
+	Image          string   `yaml:"image"`
+	Namespace      string   `yaml:"namespace,omitempty"`
+	ServiceAccount string   `yaml:"service_account,omitempty"`
+	Command        []string `yaml:"command,omitempty"`
+	Args           []string `yaml:"args,omitempty"`
 }
 
 func main() {
@@ -76,6 +78,8 @@ func main() {
 	image := jobFile.Image
 	namespace := jobFile.Namespace
 	sa := jobFile.ServiceAccount
+	command := jobFile.Command
+	args := jobFile.Args
 
 	if len(namespace) == 0 {
 		namespace = "default"
@@ -137,6 +141,8 @@ func main() {
 							Image:           image,
 							Name:            name,
 							ImagePullPolicy: corev1.PullAlways,
+							Command:         command,
+							Args:            args,
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <mariia.kotliarevskaia@gmail.com>

fixes #2 

Make command and args configurable via file. Those options are independent and can be set separately or together - depends on the docker image.

tested config 1:
```
name: curl
image: nicolaka/netshoot
command:
- "curl"
args:
  - "-s"
  - "https://example.com"
 ```
 
 output
 ```
 ./run-job -f job.yaml
Created job curl.default (5d66e0d9-4049-4e9e-aaf1-9bdbe8d422fd)
....
Job curl.default (5d66e0d9-4049-4e9e-aaf1-9bdbe8d422fd) succeeded 
Deleted job curl

Recorded: 2022-09-06 05:35:47.486519 +0000 UTC

<!doctype html>
<html>
<head>
    <title>Example Domain</title>

    <meta charset="utf-8" />
    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style type="text/css">
    body {
        background-color: #f0f0f2;
        margin: 0;
        padding: 0;
        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
        
    }
    div {
        width: 600px;
        margin: 5em auto;
        padding: 2em;
        background-color: #fdfdff;
        border-radius: 0.5em;
        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
    }
    a:link, a:visited {
        color: #38488f;
        text-decoration: none;
    }
    @media (max-width: 700px) {
        div {
            margin: 0 auto;
            width: auto;
        }
    }
    </style>    
</head>

<body>
<div>
    <h1>Example Domain</h1>
    <p>This domain is for use in illustrative examples in documents. You may use this
    domain in literature without prior coordination or asking for permission.</p>
    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
</div>
</body>
</html>
```

And then 
```
name: curl
image: ghcr.io/openfaas/curl:latest
command:
- "whoami"
```

output
```
./run-job -f job.yaml
Created job curl.default (8ce1135b-295d-4ed1-81b5-b5ec6defa6db)
....
Job curl.default (8ce1135b-295d-4ed1-81b5-b5ec6defa6db) succeeded 
Deleted job curl

Recorded: 2022-09-06 05:37:25.742354 +0000 UTC

app
```