### PR TITLE
Add KUBECONFIG env var default for kubeconfig string flag (fix #72)

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 		outFile    string
 		file       string
 	)
-	kubeConfigDefault := getEnv("KUBECONFIG", "$HOME/.kube/config")
+	kubeConfigDefault := getEnv("KUBECONFIG", os.ExpandEnv("$HOME/.kube/config"))
 
 	flag.StringVar(&outFile, "out", "", "File to write to or leave blank for STDOUT")
 	flag.StringVar(&kubeconfig, "kubeconfig", kubeConfigDefault, "Path to KUBECONFIG")

--- a/main.go
+++ b/main.go
@@ -53,9 +53,10 @@ func main() {
 		outFile    string
 		file       string
 	)
+	kubeConfigDefault := getEnv("KUBECONFIG", "$HOME/.kube/config")
 
 	flag.StringVar(&outFile, "out", "", "File to write to or leave blank for STDOUT")
-	flag.StringVar(&kubeconfig, "kubeconfig", "$HOME/.kube/config", "Path to KUBECONFIG")
+	flag.StringVar(&kubeconfig, "kubeconfig", kubeConfigDefault, "Path to KUBECONFIG")
 	flag.StringVar(&file, "f", "", "Job to run or leave blank for job.yaml in current directory")
 	flag.Parse()
 
@@ -348,4 +349,11 @@ func logs(ctx context.Context, clientset *kubernetes.Clientset, pods []string, n
 	}
 
 	return buf.String(), nil
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
Fixes #72 by making the default kubeconfig string flag value match the KUBECONFIG environment variable if that is set